### PR TITLE
Whitelist HTML element

### DIFF
--- a/src/main/java/com/google/codeu/servlets/MessageServlet.java
+++ b/src/main/java/com/google/codeu/servlets/MessageServlet.java
@@ -76,7 +76,7 @@ public class MessageServlet extends HttpServlet {
     }
 
     String user = userService.getCurrentUser().getEmail();
-    String text = Jsoup.clean(request.getParameter("text"), Whitelist.none());
+    String text = Jsoup.clean(request.getParameter("text"), Whitelist.basic());
     //Get value of a query parameter
     String recipient = request.getParameter("recipient");
 


### PR DESCRIPTION
Before this change, HTML tags were getting removed as we were skipping all html tags using ```Whitelist.None().```  We introduce ```Whitelist.basic()``` to include those HTML tags. 


**Before**:
User types: ```This is some <b>bold</b> text.```
Output: ```This is some bold text.```


**Now:**
User Types: ```This is some <b>bold</b> text.```
Output: This is some **bold** text